### PR TITLE
Append core attr

### DIFF
--- a/2018-08-SIwithVitalDynamics/module-fx.R
+++ b/2018-08-SIwithVitalDynamics/module-fx.R
@@ -87,7 +87,7 @@ afunc <- function(dat, at) {
 
   # Update attributes
   if (nArrivals > 0) {
-		# Create the mandatory EpiModel attributes, "active" and "uid", for the new nodes
+    # Create the mandatory EpiModel attributes, "active" and "uid", for the new nodes
     dat <- append_core_attr(dat, nArrivals)
 
     dat <- append_attr(dat, "status", "s", nArrivals)

--- a/2018-08-SIwithVitalDynamics/module-fx.R
+++ b/2018-08-SIwithVitalDynamics/module-fx.R
@@ -87,7 +87,9 @@ afunc <- function(dat, at) {
 
   # Update attributes
   if (nArrivals > 0) {
-    dat <- append_attr(dat, "active", 1, nArrivals)
+		# Create the mandatory EpiModel attributes, "active" and "uid", for the new nodes
+    dat <- append_core_attr(dat, nArrivals)
+
     dat <- append_attr(dat, "status", "s", nArrivals)
     dat <- append_attr(dat, "infTime", NA, nArrivals)
     dat <- append_attr(dat, "entrTime", at, nArrivals)


### PR DESCRIPTION
Modify the 2018-08-SIwithVitalDynamics `afunc()` function to use the new `append_core_attr` function

It has been tested with the `uid_attr` branch of EpiModel https://github.com/statnet/EpiModel/tree/uid_attr. It works as expected and produce the expected output. (Evaluated by adding the "raw.output = TRUE" control locally to check the content of `attr$uid`)

note: the build will probably fail as `append_core_attr` is not yet on the main EpiModel branch